### PR TITLE
Translate site to Spanish

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,84 +1,84 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="es">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Смотрите новинки и редкие фильмы без рекламы и подписок. Удобный доступ с любых устройств.">
-  <title>Твое личное кино</title>
+  <meta name="description" content="Mira estrenos y películas raras sin publicidad ni suscripciones. Acceso cómodo desde cualquier dispositivo.">
+  <title>Tu cine personal</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header>
-    <h1>Твое личное кино — без рекламы и подписок</h1>
-    <p class="subheading">Смотри любимые фильмы в один клик</p>
-    <a href="#connect" class="cta-button">Подключиться за 10 секунд</a>
-    <p class="note">Работает даже без Telegram!</p>
+    <h1>Tu cine personal: sin publicidad ni suscripciones</h1>
+    <p class="subheading">Mira tus películas favoritas con un solo clic</p>
+    <a href="#connect" class="cta-button">Conéctate en 10 segundos</a>
+    <p class="note">Funciona incluso sin Telegram</p>
   </header>
 
   <section class="features">
-    <h2>Почему это удобно</h2>
+    <h2>¿Por qué es conveniente?</h2>
     <div class="feature-cards">
       <div class="feature-card">
         <div class="icon">🎬</div>
-        <p>Новинки и редкие фильмы</p>
+        <p>Estrenos y películas raras</p>
       </div>
       <div class="feature-card">
         <div class="icon">📱</div>
-        <p>Доступ с телефона, планшета и ПК</p>
+        <p>Acceso desde teléfono, tablet y computadora</p>
       </div>
       <div class="feature-card">
         <div class="icon">🚫</div>
-        <p>Без подписок и рекламы</p>
+        <p>Sin suscripciones ni publicidad</p>
       </div>
     </div>
   </section>
 
   <section class="steps">
-    <h2>Как это работает</h2>
+    <h2>¿Cómo funciona?</h2>
     <ol>
-      <li><span class="icon">1️⃣</span> Выбери удобный формат просмотра</li>
-      <li><span class="icon">2️⃣</span> Получи доступ к каталогу</li>
-      <li><span class="icon">3️⃣</span> Смотри когда угодно</li>
+      <li><span class="icon">1️⃣</span> Elige el formato de visualización que prefieras</li>
+      <li><span class="icon">2️⃣</span> Obtén acceso al catálogo</li>
+      <li><span class="icon">3️⃣</span> Mira cuando quieras</li>
     </ol>
   </section>
 
   <section class="connection-options" id="connect">
-    <h2>Подключение</h2>
-    <a href="https://t.me/pulpocine_bot">Войти через Telegram</a>
-    <a href="#web">Смотреть через сайт / веб‑просмотр</a>
-    <a href="mailto:info@example.com">Получить доступ по почте</a>
+    <h2>Conéctate</h2>
+    <a href="https://t.me/pulpocine_bot">Iniciar sesión con Telegram</a>
+    <a href="#web">Ver a través del sitio / vista web</a>
+    <a href="mailto:info@example.com">Obtener acceso por correo</a>
   </section>
 
   <section class="reviews">
-    <h2>Отзывы</h2>
-    <img src="https://via.placeholder.com/400x200" alt="screenshot">
-    <p class="user-count">Нас уже 12 000+ зрителей</p>
+    <h2>Reseñas</h2>
+    <img src="https://via.placeholder.com/400x200" alt="captura de pantalla">
+    <p class="user-count">Ya somos más de 12,000 espectadores</p>
   </section>
 
   <section class="faq">
-    <h2>FAQ</h2>
+    <h2>Preguntas frecuentes</h2>
     <details>
-      <summary>Как получить доступ?</summary>
-      <p>Нажмите кнопку «Подключиться за 10 секунд» и следуйте инструкции.</p>
+      <summary>¿Cómo obtener acceso?</summary>
+      <p>Pulsa el botón "Conéctate en 10 segundos" y sigue las instrucciones.</p>
     </details>
     <details>
-      <summary>Нужен ли Telegram?</summary>
-      <p>Нет, сервис работает и без него.</p>
+      <summary>¿Se necesita Telegram?</summary>
+      <p>No, el servicio funciona sin él.</p>
     </details>
     <details>
-      <summary>Сколько это стоит?</summary>
-      <p>Вы платите только за выбранный формат, без подписок.</p>
+      <summary>¿Cuánto cuesta?</summary>
+      <p>Pagas solo por el formato elegido, sin suscripciones.</p>
     </details>
   </section>
 
   <footer>
-    <p>Контакты: <a href="mailto:marketing@cinealquimista.com">marketing@cinealquimista.com</a></p>
+    <p>Contacto: <a href="mailto:marketing@cinealquimista.com">marketing@cinealquimista.com</a></p>
     <div class="social">
       <a href="https://t.me/pulpocine_bot">Telegram</a>
       <a href="https://instagram.com/cinealquimista">Instagram</a>
     </div>
-    <a href="https://t.me/pulpocine_bot" class="cta-button">Войти через Telegram</a>
-    <p><a href="#">Политика конфиденциальности</a></p>
+    <a href="https://t.me/pulpocine_bot" class="cta-button">Iniciar sesión con Telegram</a>
+    <p><a href="#">Política de privacidad</a></p>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- translate `index.html` content from Russian to Spanish for Latin American audiences

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest` *(runs zero tests)*

------
https://chatgpt.com/codex/tasks/task_e_685d5a06bd848322a39d6073092a77ba